### PR TITLE
removed matomo website analytics

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 
 <head>
   <title>Page Not Found</title>
@@ -10,27 +10,6 @@
   />
   <link rel="stylesheet" href="assets/css/main.css" />
   <link rel="shortcut icon" href="images/favicon.ico" />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 <body class="index">
   <div id="page-wrapper"></div>

--- a/archive/glossary-of-stoicism-terms.html
+++ b/archive/glossary-of-stoicism-terms.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <head>
   <title>Glossary of Stoicism Terms</title>
   <meta charset="utf-8" />
@@ -10,27 +10,6 @@
   />
   <link rel="stylesheet" href="/assets/css/main.css" />
   <link rel="shortcut icon" href="/images/favicon.ico" />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 
 <body class="index">

--- a/archive/modern-stoicism-resources.html
+++ b/archive/modern-stoicism-resources.html
@@ -7,21 +7,7 @@
 		<link rel="stylesheet" href="/assets/css/main.css" />
 		<link rel="shortcut icon" href="/images/favicon.ico" />
 
-<!-- Matomo -->
-<script type="text/javascript">
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//stats.productwar.com/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '1']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<!-- End Matomo Code --> 
+
 
 </head>
 

--- a/archive/newsletter.html
+++ b/archive/newsletter.html
@@ -1,6 +1,6 @@
-<!DOCTYPE html>
+<!doctype html>
 
-<!DOCTYPE html>
+<!doctype html>
 
 <head>
   <title>Newsletter</title>
@@ -12,27 +12,6 @@
   />
   <link rel="stylesheet" href="assets/css/main.css" />
   <link rel="shortcut icon" href="images/favicon.ico" />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 <body class="index">
   <div id="page-wrapper"></div>

--- a/archive/stoic-sessions.html
+++ b/archive/stoic-sessions.html
@@ -7,21 +7,7 @@
 		<link rel="stylesheet" href="assets/css/main.css" />
 		<link rel="shortcut icon" href="images/favicon.ico" />
 
-<!-- Matomo -->
-<script type="text/javascript">
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//stats.productwar.com/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '1']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<!-- End Matomo Code --> 
+
 
 </head>
 

--- a/archive/stoic-wares-purchase.html
+++ b/archive/stoic-wares-purchase.html
@@ -6,21 +6,7 @@
 		<link rel="stylesheet" href="assets/css/main.css" />
 		<link rel="shortcut icon" href="images/favicon.ico" />
 
-<!-- Matomo -->
-<script type="text/javascript">
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//stats.productwar.com/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '1']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<!-- End Matomo Code --> 
+
 
 </head>
 

--- a/archive/stoic-wares.html
+++ b/archive/stoic-wares.html
@@ -7,21 +7,7 @@
 		<link rel="stylesheet" href="assets/css/main.css" />
 		<link rel="shortcut icon" href="images/favicon.ico" />
 
-<!-- Matomo -->
-<script type="text/javascript">
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//stats.productwar.com/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '1']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<!-- End Matomo Code --> 
+
 
 	</head>
 

--- a/contact.html
+++ b/contact.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 
 <head>
   <title>Contact</title>
@@ -10,27 +10,6 @@
   />
   <link rel="stylesheet" href="assets/css/main.css" />
   <link rel="shortcut icon" href="images/favicon.ico" />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 
 <body class="index">

--- a/donate.html
+++ b/donate.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 
 <head>
   <title>Donate</title>
@@ -10,27 +10,6 @@
   />
   <link rel="stylesheet" href="assets/css/main.css" />
   <link rel="shortcut icon" href="images/favicon.ico" />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 <body class="index">
   <div id="page-wrapper"></div>

--- a/es/comunidades-estoicas.html
+++ b/es/comunidades-estoicas.html
@@ -8,21 +8,7 @@
 			<link rel="stylesheet" href="/assets/css/main.css" />
 			<link rel="shortcut icon" href="/images/favicon.ico" />
 
-<!-- Matomo -->
-<script type="text/javascript">
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//stats.productwar.com/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '1']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<!-- End Matomo Code --> 
+
 
 
 </head>

--- a/es/equipo.html
+++ b/es/equipo.html
@@ -7,21 +7,7 @@
 		<link rel="stylesheet" href="/assets/css/main.css" />
 		<link rel="shortcut icon" href="/images/favicon.ico" />
 
-<!-- Matomo -->
-<script type="text/javascript">
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//stats.productwar.com/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '1']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<!-- End Matomo Code --> 
+
 
 
 </head>

--- a/es/misión.html
+++ b/es/misión.html
@@ -9,21 +9,7 @@
 		<link rel="stylesheet" href="/assets/css/main.css" />
 		<link rel="shortcut icon" href="/images/favicon.ico" />
 
-<!-- Matomo -->
-<script type="text/javascript">
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//stats.productwar.com/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '1']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<!-- End Matomo Code --> 
+
 
 
 	</head>

--- a/es/recursos-estoicos.html
+++ b/es/recursos-estoicos.html
@@ -7,21 +7,7 @@
 		<link rel="stylesheet" href="/assets/css/main.css" />
 		<link rel="shortcut icon" href="/images/favicon.ico" />
 
-<!-- Matomo -->
-<script type="text/javascript">
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//stats.productwar.com/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '1']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<!-- End Matomo Code --> 
+
 
 
 </head>

--- a/events.html
+++ b/events.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <head>
   <title>Events</title>
   <meta charset="utf-8" />
@@ -9,27 +9,6 @@
   />
   <link rel="stylesheet" href="assets/css/main.css" />
   <link rel="shortcut icon" href="images/favicon.ico" />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 <body class="index">
   <div id="page-wrapper"></div>

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <head>
   <title>The Stoic Fellowship</title>
   <meta charset="utf-8" />
@@ -9,27 +9,6 @@
   />
   <link rel="stylesheet" href="assets/css/main.css" />
   <link rel="shortcut icon" href="images/favicon.ico" />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 
 <!-- Body -->
@@ -94,26 +73,44 @@
           <div
             style="display: flex; align-items: center; gap: 10px; margin: 20px"
           >
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" width="28" height="28">
-              <circle cx="10" cy="10" r="8" fill="#880E4F"/>
-              <path d="M10 4l1.2 3.7h3.9l-3.1 2.3 1.2 3.7L10 11.4l-3.2 2.3 1.2-3.7-3.1-2.3h3.9L10 4z" fill="white"/>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              width="28"
+              height="28"
+            >
+              <circle cx="10" cy="10" r="8" fill="#880E4F" />
+              <path
+                d="M10 4l1.2 3.7h3.9l-3.1 2.3 1.2 3.7L10 11.4l-3.2 2.3 1.2-3.7-3.1-2.3h3.9L10 4z"
+                fill="white"
+              />
             </svg>
             <p style="margin: 0">Member Stoas</p>
           </div>
           <div
             style="display: flex; align-items: center; gap: 10px; margin: 20px"
           >
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" width="28" height="28">
-              <circle cx="10" cy="10" r="8" fill="#E65100"/>
-              <rect x="8" y="8" width="4" height="4" fill="white"/>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              width="28"
+              height="28"
+            >
+              <circle cx="10" cy="10" r="8" fill="#E65100" />
+              <rect x="8" y="8" width="4" height="4" fill="white" />
             </svg>
             <p style="margin: 0">Other Active Stoas</p>
           </div>
           <div
             style="display: flex; align-items: center; gap: 10px; margin: 20px"
           >
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" width="12" height="12">
-              <circle cx="10" cy="10" r="8" fill="#0F9D58"/>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              width="12"
+              height="12"
+            >
+              <circle cx="10" cy="10" r="8" fill="#0F9D58" />
             </svg>
             <p style="margin: 0">Stoics Seeking Stoas</p>
           </div>

--- a/info/updates-from-stoas/2020-07-updates.html
+++ b/info/updates-from-stoas/2020-07-updates.html
@@ -1,31 +1,10 @@
-<!DOCTYPE html>
+<!doctype html>
 <head>
   <title>Updates from Stoics</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="/assets/css/main.css" />
   <link rel="shortcut icon" href="images/favicon.ico" />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 <body class="index">
   <div id="page-wrapper">

--- a/info/updates-from-stoas/2021-04-updates.html
+++ b/info/updates-from-stoas/2021-04-updates.html
@@ -1,31 +1,10 @@
-<!DOCTYPE html>
+<!doctype html>
 <head>
   <title>Updates from Stoics</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="/assets/css/main.css" />
   <link rel="shortcut icon" href="/images/favicon.ico" />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 <body class="index">
   <div id="page-wrapper">

--- a/info/updates-from-stoas/2021-10-updates.html
+++ b/info/updates-from-stoas/2021-10-updates.html
@@ -1,31 +1,10 @@
-<!DOCTYPE html>
+<!doctype html>
 <head>
   <title>Updates from Stoics</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="/assets/css/main.css" />
   <link rel="shortcut icon" href="/images/favicon.ico" />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 <body class="index">
   <div id="page-wrapper">

--- a/info/updates-from-stoas/2022-01-updates.html
+++ b/info/updates-from-stoas/2022-01-updates.html
@@ -1,31 +1,10 @@
-<!DOCTYPE html>
+<!doctype html>
 <head>
   <title>Updates from Stoics</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="/assets/css/main.css" />
   <link rel="shortcut icon" href="/images/favicon.ico" />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 <body class="index">
   <div id="page-wrapper">

--- a/info/updates-from-stoas/2022-04-updates.html
+++ b/info/updates-from-stoas/2022-04-updates.html
@@ -1,31 +1,10 @@
-<!DOCTYPE html>
+<!doctype html>
 <head>
   <title>Updates from Stoics</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="/assets/css/main.css" />
   <link rel="shortcut icon" href="/images/favicon.ico" />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 <body class="index">
   <div id="page-wrapper">

--- a/info/updates-from-stoas/2022-07-updates.html
+++ b/info/updates-from-stoas/2022-07-updates.html
@@ -1,31 +1,10 @@
-<!DOCTYPE html>
+<!doctype html>
 <head>
   <title>Updates from Stoics</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="/assets/css/main.css" />
   <link rel="shortcut icon" href="/images/favicon.ico" />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 <body class="index">
   <div id="page-wrapper">

--- a/info/updates-from-stoas/2022-10-updates.html
+++ b/info/updates-from-stoas/2022-10-updates.html
@@ -1,31 +1,10 @@
-<!DOCTYPE html>
+<!doctype html>
 <head>
   <title>Updates from Stoics</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="/assets/css/main.css" />
   <link rel="shortcut icon" href="/images/favicon.ico" />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 <body class="index">
   <div id="page-wrapper">

--- a/info/updates-from-stoas/2023-01-updates.html
+++ b/info/updates-from-stoas/2023-01-updates.html
@@ -1,31 +1,10 @@
-<!DOCTYPE html>
+<!doctype html>
 <head>
   <title>Updates from Stoics</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="/assets/css/main.css" />
   <link rel="shortcut icon" href="/images/favicon.ico" />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 <body class="index">
   <div id="page-wrapper">

--- a/info/updates-from-stoas/2023-04-updates.html
+++ b/info/updates-from-stoas/2023-04-updates.html
@@ -1,31 +1,10 @@
-<!DOCTYPE html>
+<!doctype html>
 <head>
   <title>Updates from Stoics</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="/assets/css/main.css" />
   <link rel="shortcut icon" href="/images/favicon.ico" />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 <body class="index">
   <div id="page-wrapper">

--- a/info/updates-from-stoas/2023-07-updates.html
+++ b/info/updates-from-stoas/2023-07-updates.html
@@ -1,31 +1,10 @@
-<!DOCTYPE html>
+<!doctype html>
 <head>
   <title>Updates from Stoics</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="/assets/css/main.css" />
   <link rel="shortcut icon" href="/images/favicon.ico" />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 <body class="index">
   <div id="page-wrapper">

--- a/info/updates-from-stoas/2023-10-updates.html
+++ b/info/updates-from-stoas/2023-10-updates.html
@@ -1,31 +1,10 @@
-<!DOCTYPE html>
+<!doctype html>
 <head>
   <title>Updates from Stoics</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="/assets/css/main.css" />
   <link rel="shortcut icon" href="/images/favicon.ico" />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 <body class="index">
   <div id="page-wrapper">

--- a/info/updates-from-stoas/main.html
+++ b/info/updates-from-stoas/main.html
@@ -1,31 +1,10 @@
-<!DOCTYPE html>
+<!doctype html>
 <head>
   <title>Updates from Stoics</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="/assets/css/main.css" />
   <link rel="shortcut icon" href="/images/favicon.ico" />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 <body class="index">
   <div id="page-wrapper">

--- a/info/updates-from-stoas/stoa-spotlight/redwood-stoa.html
+++ b/info/updates-from-stoas/stoa-spotlight/redwood-stoa.html
@@ -1,31 +1,10 @@
-<!DOCTYPE html>
+<!doctype html>
 <head>
   <title>Updates from Stoics</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="/assets/css/main.css" />
   <link rel="shortcut icon" href="/images/favicon.ico" />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 <body class="index">
   <div id="page-wrapper">

--- a/interviews.html
+++ b/interviews.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 
 <head>
   <title>Interviews</title>
@@ -10,27 +10,6 @@
   />
   <link rel="stylesheet" href="assets/css/main.css" />
   <link rel="shortcut icon" href="images/favicon.ico" />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 <body class="index">
   <div id="page-wrapper">

--- a/join-a-stoa.html
+++ b/join-a-stoa.html
@@ -24,26 +24,7 @@
     rel="stylesheet"
   />
 
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
+  
 </head>
 <body class="index">
   <div id="page-wrapper">

--- a/join.html
+++ b/join.html
@@ -1,31 +1,10 @@
-<!DOCTYPE html>
+<!doctype html>
 <head>
   <title>Join a Stoa</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="assets/css/main.css" />
   <link rel="shortcut icon" href="images/favicon.ico" />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 <body class="index">
   <div id="page-wrapper"></div>

--- a/logo.html
+++ b/logo.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <head>
   <title>Our Logo</title>
   <meta charset="utf-8" />
@@ -9,27 +9,6 @@
   />
   <link rel="stylesheet" href="assets/css/main.css" />
   <link rel="shortcut icon" href="images/favicon.ico" />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 <body class="index">
   <div id="page-wrapper"></div>

--- a/membership.html
+++ b/membership.html
@@ -26,26 +26,7 @@
     rel="stylesheet"
   />
 
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
+  
 </head>
 
 <body class="index">

--- a/mission.html
+++ b/mission.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <head>
   <title>Our Mission</title>
   <meta charset="utf-8" />
@@ -9,27 +9,6 @@
   />
   <link rel="stylesheet" href="assets/css/main.css" />
   <link rel="shortcut icon" href="images/favicon.ico" />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 
 <body class="index">

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -1,31 +1,10 @@
-<!DOCTYPE html>
+<!doctype html>
 <head>
   <title>Privacy Policy</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="assets/css/main.css" />
   <link rel="shortcut icon" href="images/favicon.ico" />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 
 <body class="index">

--- a/resources/stoicism-resources.html
+++ b/resources/stoicism-resources.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <head>
   <title>Stoicism Resources</title>
   <meta charset="utf-8" />
@@ -9,27 +9,6 @@
   />
   <link rel="stylesheet" href="/assets/css/main.css" />
   <link rel="shortcut icon" href="/images/favicon.ico" />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 
 <body class="index">

--- a/service/index.html
+++ b/service/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <head>
   <title>Service</title>
   <meta charset="utf-8" />
@@ -9,27 +9,6 @@
   />
   <link rel="stylesheet" href="/assets/css/main.css" />
   <link rel="shortcut icon" href="/images/favicon.ico" />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 
 <body class="index">
@@ -110,14 +89,16 @@
           </p>
 
           <p>
-            If you're a member of a local Stoa, you can collaborate on a
-            service project with other members of your group. Or volunteer your
-            time as an individual in your local community, making new friends
-            along the way. Through volunteering, we strengthen our bond with
-            friends and serve our community. Start planning today and together
-            we'll celebrate 1000 acts of friendship in April. For more
-            information contact:
-            <a href="mailto:james@stoicfellowship.com">james@stoicfellowship.com</a>
+            If you're a member of a local Stoa, you can collaborate on a service
+            project with other members of your group. Or volunteer your time as
+            an individual in your local community, making new friends along the
+            way. Through volunteering, we strengthen our bond with friends and
+            serve our community. Start planning today and together we'll
+            celebrate 1000 acts of friendship in April. For more information
+            contact:
+            <a href="mailto:james@stoicfellowship.com"
+              >james@stoicfellowship.com</a
+            >
           </p>
         </div>
 
@@ -157,12 +138,12 @@
             friendship isn't about need—it's about virtue. A good friend
             sharpens your perspective, challenges your thinking, and supports
             your growth while you do the same for them. And it doesn't stop
-            there—every small, random act of kindness turns strangers into allies
-            and makes the world a little friendlier. Together, we practice
-            empathy, patience, and cooperation—the very skills that help
-            communities thrive. Even better, we actually enjoy the journey more.
-            So this Month of Service, don't go it alone—make a friend, be a
-            friend, and multiply the good you can do.
+            there—every small, random act of kindness turns strangers into
+            allies and makes the world a little friendlier. Together, we
+            practice empathy, patience, and cooperation—the very skills that
+            help communities thrive. Even better, we actually enjoy the journey
+            more. So this Month of Service, don't go it alone—make a friend, be
+            a friend, and multiply the good you can do.
           </p>
 
           <p>
@@ -200,13 +181,19 @@
               >
             </li>
             <li>
-              Share your photos on the Stoic Fellowship Network <a href="https://social.stoicfellowship.com/spaces/12132858/feed" target="_blank">Service Page</a>
+              Share your photos on the Stoic Fellowship Network
+              <a
+                href="https://social.stoicfellowship.com/spaces/12132858/feed"
+                target="_blank"
+                >Service Page</a
+              >
             </li>
           </ul>
 
           <p>
-            Participants who share four acts of kindness—one for each virtue—will
-            receive the <strong>2026 Month of Service Badge</strong>:
+            Participants who share four acts of kindness—one for each
+            virtue—will receive the
+            <strong>2026 Month of Service Badge</strong>:
           </p>
         </div>
 

--- a/service/month-of-service.html
+++ b/service/month-of-service.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <head>
   <title>Month of Service</title>
   <meta charset="utf-8" />
@@ -9,27 +9,6 @@
   />
   <link rel="stylesheet" href="/assets/css/main.css" />
   <link rel="shortcut icon" href="/images/favicon.ico" />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 
 <body class="index">

--- a/start-a-stoa.html
+++ b/start-a-stoa.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <head>
   <title>Start a Stoa</title>
   <meta charset="utf-8" />
@@ -9,27 +9,6 @@
   />
   <link rel="stylesheet" href="assets/css/main.css" />
   <link rel="shortcut icon" href="images/favicon.ico" />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 <body class="index">
   <div id="page-wrapper">

--- a/stoic-groups.html
+++ b/stoic-groups.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <head>
   <title>Stoicism Communities</title>
   <meta charset="utf-8" />
@@ -23,27 +23,6 @@
     rel="stylesheet"
   />
   <!-- End Mapbox-->
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 
 <!-- <div class="announcement" class="reveal">

--- a/team.html
+++ b/team.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <head>
   <title>Team</title>
   <meta charset="utf-8" />
@@ -13,27 +13,6 @@
     rel="stylesheet"
     href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
   />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 
 <body class="index">

--- a/terms-of-use.html
+++ b/terms-of-use.html
@@ -1,31 +1,10 @@
-<!DOCTYPE html>
+<!doctype html>
 <head>
   <title>Terms of Use</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="assets/css/main.css" />
   <link rel="shortcut icon" href="images/favicon.ico" />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 
 <body class="index">

--- a/volunteer.html
+++ b/volunteer.html
@@ -1,31 +1,10 @@
-<!DOCTYPE html>
+<!doctype html>
 <head>
   <title>Volunteer</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="assets/css/main.css" />
   <link rel="shortcut icon" href="images/favicon.ico" />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 
 <body class="index">

--- a/volunteer/apply.html
+++ b/volunteer/apply.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <head>
   <title>Apply</title>
   <meta charset="utf-8" />
@@ -19,27 +19,6 @@
     href="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.css"
     rel="stylesheet"
   />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 
 <body class="index">

--- a/volunteer/role.html
+++ b/volunteer/role.html
@@ -1,31 +1,10 @@
-<!DOCTYPE html>
+<!doctype html>
 <head>
   <title>Volunteer Roles</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="/assets/css/main.css" />
   <link rel="shortcut icon" href="/images/favicon.ico" />
-
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = (window._paq = window._paq || [])
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView'])
-    _paq.push(['enableLinkTracking'])
-    ;(function () {
-      var u = '//stats.productwar.com/'
-      _paq.push(['setTrackerUrl', u + 'matomo.php'])
-      _paq.push(['setSiteId', '1'])
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0]
-      g.type = 'text/javascript'
-      g.async = true
-      g.src = u + 'matomo.js'
-      s.parentNode.insertBefore(g, s)
-    })()
-  </script>
-  <!-- End Matomo Code -->
 </head>
 
 <body class="index">


### PR DESCRIPTION
**Summary:** Removed Matomo tracking code from all locations.
**Why:** We've decommissioned the Digital Ocean droplet and are no longer tracking website visits via Matomo.
**Testing:** N/A
**Notes:** Before decommissioning the droplet, I took exports of relevant historical data which now lives in the TSF Google Drive.