### PR TITLE
Fix stoa form submission by using select type for Notion

### DIFF
--- a/membership.html
+++ b/membership.html
@@ -81,7 +81,7 @@
       </h3>
       <select name="meeting_preference" required>
         <option value="">Select preference</option>
-        <option>Local</option>
+        <option>In-person</option>
         <option>Virtual</option>
         <option>Hybrid</option>
       </select>

--- a/netlify/functions/submit-stoa.js
+++ b/netlify/functions/submit-stoa.js
@@ -2,6 +2,12 @@ const fetch = require('node-fetch')
 
 const txt = (val) => [{ text: { content: String(val ?? '').slice(0, 2000) } }]
 
+// Notion select options can't contain commas and must be non-empty.
+const select = (val) => {
+  const name = String(val ?? '').replace(/,/g, ' ').trim().slice(0, 100)
+  return { select: name ? { name } : null }
+}
+
 exports.handler = async function handler(event) {
   if (event.httpMethod !== 'POST') {
     return { statusCode: 405, body: 'Method Not Allowed' }
@@ -47,14 +53,14 @@ exports.handler = async function handler(event) {
         parent: { database_id: NOTION_STOA_DB_ID },
         properties: {
           Name: { title: txt(stoa_name) },
-          'Stoa Type': { rich_text: txt(stoa_type) },
+          'Stoa Type': select(stoa_type),
           Location: { rich_text: txt(location) },
           Latitude: { number: latitude !== '' && latitude != null ? parseFloat(latitude) : null },
           Longitude: { number: longitude !== '' && longitude != null ? parseFloat(longitude) : null },
           Website: { url: website || null },
           Language: { rich_text: txt(stoa_language) },
           Timezone: { rich_text: txt(timezone) },
-          'Meeting Frequency': { rich_text: txt(meeting_frequency) },
+          'Meeting Frequency': select(meeting_frequency),
           Description: { rich_text: txt(description) },
           Facilitator: { rich_text: txt(name) },
           Email: { email: email || null },


### PR DESCRIPTION
## Problem

New stoa submissions from the membership form were failing with a Notion `validation_error`:

> Stoa Type is expected to be select. Meeting Frequency is expected to be select.

The `Stoa Type` and `Meeting Frequency` properties in the Notion stoa database are configured as **select**, but `submit-stoa.js` was sending them as `rich_text`.

## Changes

- **`netlify/functions/submit-stoa.js`**: add a `select()` helper and send `Stoa Type` and `Meeting Frequency` as `select` instead of `rich_text`. The helper sanitizes values for Notion's select constraints — strips commas (illegal in select option names), trims, caps at 100 chars, and sends `null` when empty.
- **`membership.html`**: change the Stoa Type option `Local` → `In-person` so it exactly matches the Notion select option (Hybrid / Virtual / In-person), avoiding a duplicate option being created. Meeting Frequency options (Weekly / Monthly / Quarterly / Other) already match exactly.

## Deploy note

Requires the `Stoa Type` and `Meeting Frequency` properties in the Notion stoa DB to be **Select** type (they currently are). The Supabase mirror and Brevo email still send the raw strings and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)