### PR TITLE
Show Pending stoa seekers on map instead of Closed

### DIFF
--- a/netlify/functions/get-map-data.js
+++ b/netlify/functions/get-map-data.js
@@ -87,7 +87,7 @@ exports.handler = async function handler(event) {
       ),
       queryAllPages(
         NOTION_JOIN_STOA_DB_ID,
-        { property: 'Status', status: { equals: 'Closed' } },
+        { property: 'Status', status: { equals: 'Pending' } },
         NOTION_API_KEY
       ),
     ])


### PR DESCRIPTION
## Summary
- The map's stoa seekers layer was filtering the Join-Stoa Notion DB to `Status = "Closed"`. This changes it to `Status = "Pending"` so seekers still awaiting placement show up as dots.

## Notes
- Verified that the Join-Stoa database has a status option named "Pending".

🤖 Generated with [Claude Code](https://claude.com/claude-code)