### PR TITLE
Map data caching, Notion 429 retry, and Supabase removal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,16 @@ Forms are handled by Netlify serverless functions (`netlify/functions/`). They s
 
 The map uses **Mapbox** — the token is served via `netlify/functions/get-mapbox-token.js` rather than hardcoded in the frontend.
 
+### Notion write notes
+
+- All `submit-*` functions write to Notion as the **primary (and only) store**. The Supabase mirror was removed (2026-07-26); Supabase env-var cleanup in Netlify and the historical data export are being handled separately by the maintainer.
+- Notion queries go through `fetchWithRetry` (`netlify/functions/utils/notion-fetch.js`), which retries 429/529 with `Retry-After` backoff.
+- **Notion's `url` property accepts arbitrary text** — it does NOT reject malformed URIs (bare domains, free text). Confirmed against live data. So don't assume a bad URL value is what's failing a submission.
+
+### Open issue: volunteer form submission failures
+
+Some volunteer applications were reported failing / not appearing in Notion (all roles post through the same `apply.html` → `submit-volunteer.js`, so this is value-dependent, not role-specific). Root cause is **not yet identified** — an early URL-validation theory was ruled out (see note above). Investigation deferred until the volunteer pages are unhidden. Fastest diagnostic: the `Notion error: …` line in the Netlify function logs for a failed `submit-volunteer` invocation gives Notion's exact validation message.
+
 ## Key Files
 
 - `assets/js/headerFooter.js` / `headerFooterChild.js` — injects the shared nav and footer into every page

--- a/netlify/functions/get-map-data.js
+++ b/netlify/functions/get-map-data.js
@@ -1,5 +1,23 @@
 const fetch = require('node-fetch')
 
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+// Notion rate limits to ~3 req/s per integration and returns 429 (or 529 when
+// overloaded) with a Retry-After header. Honor it with a few bounded retries so
+// a transient limit becomes a short delay instead of a broken map.
+async function fetchWithRetry(url, options, { retries = 4, maxDelayMs = 8000 } = {}) {
+  for (let attempt = 0; ; attempt++) {
+    const res = await fetch(url, options)
+    if (res.status !== 429 && res.status !== 529) return res
+    if (attempt >= retries) return res
+
+    const retryAfter = parseFloat(res.headers.get('retry-after'))
+    const headerDelay = Number.isFinite(retryAfter) ? retryAfter * 1000 : 0
+    const backoff = Math.min(maxDelayMs, 500 * 2 ** attempt)
+    await sleep(Math.min(maxDelayMs, Math.max(headerDelay, backoff)))
+  }
+}
+
 async function queryAllPages(databaseId, filter, notionKey) {
   const results = []
   let cursor = undefined
@@ -9,7 +27,7 @@ async function queryAllPages(databaseId, filter, notionKey) {
     const body = { filter, page_size: 100 }
     if (cursor) body.start_cursor = cursor
 
-    const res = await fetch(`https://api.notion.com/v1/databases/${databaseId}/query`, {
+    const res = await fetchWithRetry(`https://api.notion.com/v1/databases/${databaseId}/query`, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${notionKey}`,
@@ -118,7 +136,12 @@ exports.handler = async function handler(event) {
       statusCode: 200,
       headers: {
         'Content-Type': 'application/json',
-        'Cache-Control': 'public, max-age=600',
+        // Cache-Control alone only reaches browsers; Netlify's CDN caches
+        // function responses only via Netlify-CDN-Cache-Control. `durable`
+        // shares one cached copy across all edge nodes, so a traffic spike
+        // collapses to a single Notion query burst per minute.
+        'Cache-Control': 'public, max-age=60',
+        'Netlify-CDN-Cache-Control': 'public, durable, max-age=60, stale-while-revalidate=60',
       },
       body: JSON.stringify({ stoas: resolvedStoas, seekers: resolvedSeekers }),
     }

--- a/netlify/functions/get-map-data.js
+++ b/netlify/functions/get-map-data.js
@@ -1,22 +1,5 @@
 const fetch = require('node-fetch')
-
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
-
-// Notion rate limits to ~3 req/s per integration and returns 429 (or 529 when
-// overloaded) with a Retry-After header. Honor it with a few bounded retries so
-// a transient limit becomes a short delay instead of a broken map.
-async function fetchWithRetry(url, options, { retries = 4, maxDelayMs = 8000 } = {}) {
-  for (let attempt = 0; ; attempt++) {
-    const res = await fetch(url, options)
-    if (res.status !== 429 && res.status !== 529) return res
-    if (attempt >= retries) return res
-
-    const retryAfter = parseFloat(res.headers.get('retry-after'))
-    const headerDelay = Number.isFinite(retryAfter) ? retryAfter * 1000 : 0
-    const backoff = Math.min(maxDelayMs, 500 * 2 ** attempt)
-    await sleep(Math.min(maxDelayMs, Math.max(headerDelay, backoff)))
-  }
-}
+const { fetchWithRetry } = require('./utils/notion-fetch')
 
 async function queryAllPages(databaseId, filter, notionKey) {
   const results = []

--- a/netlify/functions/submit-contact.js
+++ b/netlify/functions/submit-contact.js
@@ -12,8 +12,6 @@ exports.handler = async function handler(event) {
 
   const ip = event.headers['x-nf-client-connection-ip'] || 'unknown'
 
-  const SUPABASE_URL = process.env.SUPABASE_URL
-  const SUPABASE_KEY = process.env.SUPABASE_KEY
   const BREVO_API_KEY = process.env.BREVO_API_KEY
   const NOTION_API_KEY = process.env.NOTION_API_KEY
   const NOTION_CONTACT_DB_ID = process.env.NOTION_CONTACT_DB_ID
@@ -43,35 +41,6 @@ exports.handler = async function handler(event) {
     })
     if (!notionRes.ok) {
       throw new Error(`Notion error: ${await notionRes.text()}`)
-    }
-
-    // Save to Supabase (non-fatal mirror)
-    if (SUPABASE_URL && SUPABASE_KEY) {
-      try {
-        const supabaseRes = await fetch(
-          `${SUPABASE_URL}/rest/v1/contact_submissions`,
-          {
-            method: 'POST',
-            headers: {
-              apikey: SUPABASE_KEY,
-              Authorization: `Bearer ${SUPABASE_KEY}`,
-              'Content-Type': 'application/json',
-              Prefer: 'return=representation',
-            },
-            body: JSON.stringify({
-              name,
-              email,
-              message,
-              ip_address: ip,
-            }),
-          }
-        )
-        if (!supabaseRes.ok) {
-          console.warn('Supabase error (non-fatal):', await supabaseRes.text())
-        }
-      } catch (supabaseErr) {
-        console.warn('Supabase error (non-fatal):', supabaseErr.message)
-      }
     }
 
     // Send Email via Brevo (non-fatal)

--- a/netlify/functions/submit-contact.js
+++ b/netlify/functions/submit-contact.js
@@ -1,4 +1,5 @@
 const fetch = require('node-fetch')
+const { fetchWithRetry } = require('./utils/notion-fetch')
 
 const txt = (val) => [{ text: { content: String(val ?? '').slice(0, 2000) } }]
 
@@ -22,7 +23,7 @@ exports.handler = async function handler(event) {
     if (!NOTION_API_KEY || !NOTION_CONTACT_DB_ID) {
       throw new Error('Notion not configured')
     }
-    const notionRes = await fetch('https://api.notion.com/v1/pages', {
+    const notionRes = await fetchWithRetry('https://api.notion.com/v1/pages', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${NOTION_API_KEY}`,

--- a/netlify/functions/submit-join-stoa.js
+++ b/netlify/functions/submit-join-stoa.js
@@ -1,4 +1,5 @@
 const fetch = require('node-fetch')
+const { fetchWithRetry } = require('./utils/notion-fetch')
 
 const txt = (val) => [{ text: { content: String(val ?? '').slice(0, 2000) } }]
 
@@ -37,7 +38,7 @@ exports.handler = async function handler(event) {
     if (!NOTION_API_KEY || !NOTION_JOIN_STOA_DB_ID) {
       throw new Error('Notion not configured')
     }
-    const notionRes = await fetch('https://api.notion.com/v1/pages', {
+    const notionRes = await fetchWithRetry('https://api.notion.com/v1/pages', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${NOTION_API_KEY}`,

--- a/netlify/functions/submit-join-stoa.js
+++ b/netlify/functions/submit-join-stoa.js
@@ -21,8 +21,6 @@ exports.handler = async function handler(event) {
     consent,
   } = JSON.parse(event.body)
 
-  const SUPABASE_URL = process.env.SUPABASE_URL
-  const SUPABASE_KEY = process.env.SUPABASE_KEY
   const BREVO_API_KEY = process.env.BREVO_API_KEY
   const NOTION_API_KEY = process.env.NOTION_API_KEY
   const NOTION_JOIN_STOA_DB_ID = process.env.NOTION_JOIN_STOA_DB_ID
@@ -64,42 +62,6 @@ exports.handler = async function handler(event) {
     })
     if (!notionRes.ok) {
       throw new Error(`Notion error: ${await notionRes.text()}`)
-    }
-
-    // Save to Supabase (non-fatal mirror)
-    if (SUPABASE_URL && SUPABASE_KEY) {
-      try {
-        const supabaseRes = await fetch(
-          `${SUPABASE_URL}/rest/v1/join_stoa_submissions`,
-          {
-            method: 'POST',
-            headers: {
-              apikey: SUPABASE_KEY,
-              Authorization: `Bearer ${SUPABASE_KEY}`,
-              'Content-Type': 'application/json',
-              Prefer: 'return=representation',
-            },
-            body: JSON.stringify({
-              name,
-              email,
-              location,
-              latitude,
-              longitude,
-              preferred_language,
-              meeting_preference,
-              additional_details,
-              consent,
-              ip_address,
-              submitted_at: new Date().toISOString(),
-            }),
-          }
-        )
-        if (!supabaseRes.ok) {
-          console.warn('Supabase error (non-fatal):', await supabaseRes.text())
-        }
-      } catch (supabaseErr) {
-        console.warn('Supabase error (non-fatal):', supabaseErr.message)
-      }
     }
 
     // Send notification via Brevo (non-fatal)

--- a/netlify/functions/submit-stoa.js
+++ b/netlify/functions/submit-stoa.js
@@ -1,4 +1,5 @@
 const fetch = require('node-fetch')
+const { fetchWithRetry } = require('./utils/notion-fetch')
 
 const txt = (val) => [{ text: { content: String(val ?? '').slice(0, 2000) } }]
 
@@ -42,7 +43,7 @@ exports.handler = async function handler(event) {
     if (!NOTION_API_KEY || !NOTION_STOA_DB_ID) {
       throw new Error('Notion not configured')
     }
-    const notionRes = await fetch('https://api.notion.com/v1/pages', {
+    const notionRes = await fetchWithRetry('https://api.notion.com/v1/pages', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${NOTION_API_KEY}`,

--- a/netlify/functions/submit-stoa.js
+++ b/netlify/functions/submit-stoa.js
@@ -32,8 +32,6 @@ exports.handler = async function handler(event) {
 
   const ip = event.headers['x-nf-client-connection-ip'] || 'unknown'
 
-  const SUPABASE_URL = process.env.SUPABASE_URL
-  const SUPABASE_KEY = process.env.SUPABASE_KEY
   const BREVO_API_KEY = process.env.BREVO_API_KEY
   const NOTION_API_KEY = process.env.NOTION_API_KEY
   const NOTION_STOA_DB_ID = process.env.NOTION_STOA_DB_ID
@@ -72,45 +70,6 @@ exports.handler = async function handler(event) {
     })
     if (!notionRes.ok) {
       throw new Error(`Notion error: ${await notionRes.text()}`)
-    }
-
-    // Save to Supabase (non-fatal mirror)
-    if (SUPABASE_URL && SUPABASE_KEY) {
-      try {
-        const supabaseRes = await fetch(
-          `${SUPABASE_URL}/rest/v1/stoa_submissions`,
-          {
-            method: 'POST',
-            headers: {
-              apikey: SUPABASE_KEY,
-              Authorization: `Bearer ${SUPABASE_KEY}`,
-              'Content-Type': 'application/json',
-              Prefer: 'return=representation',
-            },
-            body: JSON.stringify({
-              stoa_name,
-              stoa_type,
-              location,
-              latitude,
-              longitude,
-              website,
-              stoa_language,
-              timezone,
-              meeting_frequency,
-              description,
-              name,
-              email,
-              submitted_at,
-              ip_address: ip,
-            }),
-          }
-        )
-        if (!supabaseRes.ok) {
-          console.warn('Supabase error (non-fatal):', await supabaseRes.text())
-        }
-      } catch (supabaseErr) {
-        console.warn('Supabase error (non-fatal):', supabaseErr.message)
-      }
     }
 
     // Send Email via Brevo (non-fatal notification)

--- a/netlify/functions/submit-volunteer.js
+++ b/netlify/functions/submit-volunteer.js
@@ -1,4 +1,5 @@
 const fetch = require('node-fetch')
+const { fetchWithRetry } = require('./utils/notion-fetch')
 
 const txt = (val) => [{ text: { content: String(val ?? '').slice(0, 2000) } }]
 
@@ -22,7 +23,7 @@ exports.handler = async function handler(event) {
     if (!NOTION_API_KEY || !NOTION_VOLUNTEER_DB_ID) {
       throw new Error('Notion not configured')
     }
-    const notionRes = await fetch('https://api.notion.com/v1/pages', {
+    const notionRes = await fetchWithRetry('https://api.notion.com/v1/pages', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${NOTION_API_KEY}`,

--- a/netlify/functions/submit-volunteer.js
+++ b/netlify/functions/submit-volunteer.js
@@ -8,8 +8,6 @@ exports.handler = async function handler(event) {
     return { statusCode: 405, body: 'Method Not Allowed' }
   }
 
-  const SUPABASE_URL = process.env.SUPABASE_URL
-  const SUPABASE_KEY = process.env.SUPABASE_KEY
   const BREVO_API_KEY = process.env.BREVO_API_KEY
   const NOTION_API_KEY = process.env.NOTION_API_KEY
   const NOTION_VOLUNTEER_DB_ID = process.env.NOTION_VOLUNTEER_DB_ID
@@ -55,33 +53,6 @@ exports.handler = async function handler(event) {
     })
     if (!notionRes.ok) {
       throw new Error(`Notion error: ${await notionRes.text()}`)
-    }
-
-    // Save to Supabase (non-fatal mirror)
-    if (SUPABASE_URL && SUPABASE_KEY) {
-      try {
-        const supabaseRes = await fetch(
-          `${SUPABASE_URL}/rest/v1/volunteer_applications`,
-          {
-            method: 'POST',
-            headers: {
-              apikey: SUPABASE_KEY,
-              Authorization: `Bearer ${SUPABASE_KEY}`,
-              'Content-Type': 'application/json',
-              Prefer: 'return=representation',
-            },
-            body: JSON.stringify({
-              ...applicantData,
-              user_ip: ip,
-            }),
-          }
-        )
-        if (!supabaseRes.ok) {
-          console.warn('Supabase error (non-fatal):', await supabaseRes.text())
-        }
-      } catch (supabaseErr) {
-        console.warn('Supabase error (non-fatal):', supabaseErr.message)
-      }
     }
 
     // Format HTML email content

--- a/netlify/functions/utils/notion-fetch.js
+++ b/netlify/functions/utils/notion-fetch.js
@@ -1,0 +1,21 @@
+const fetch = require('node-fetch')
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+// Notion rate limits to ~3 req/s per integration and returns 429 (or 529 when
+// overloaded) with a Retry-After header. Honor it with a few bounded retries so
+// a transient limit becomes a short delay instead of a failed request.
+async function fetchWithRetry(url, options, { retries = 4, maxDelayMs = 8000 } = {}) {
+  for (let attempt = 0; ; attempt++) {
+    const res = await fetch(url, options)
+    if (res.status !== 429 && res.status !== 529) return res
+    if (attempt >= retries) return res
+
+    const retryAfter = parseFloat(res.headers.get('retry-after'))
+    const headerDelay = Number.isFinite(retryAfter) ? retryAfter * 1000 : 0
+    const backoff = Math.min(maxDelayMs, 500 * 2 ** attempt)
+    await sleep(Math.min(maxDelayMs, Math.max(headerDelay, backoff)))
+  }
+}
+
+module.exports = { fetchWithRetry }


### PR DESCRIPTION
## Summary
Three related changes to the Notion-backed functions.

### 1. CDN caching for `/get-map-data`
Adds `Netlify-CDN-Cache-Control: public, durable, max-age=60, stale-while-revalidate=60`. A plain `Cache-Control` header only reaches browsers — Netlify's CDN caches function responses only via `Netlify-CDN-Cache-Control`. `durable` shares one cached copy across all edge nodes, so a spike collapses to a single Notion query burst per minute instead of one per visitor. `stale-while-revalidate` means visitors never wait on Notion at expiry.

### 2. Consistent Notion 429/529 retry
- `fetchWithRetry` in `netlify/functions/utils/notion-fetch.js` (the `utils/` subdir isn't deployed as a function, just bundled by esbuild).
- Honors the `Retry-After` header with bounded exponential backoff (up to 4 retries, 8s cap).
- Applied to the Notion API call in `get-map-data.js` and all four `submit-*` functions.

### 3. Remove the Supabase mirror
Removed the non-fatal Supabase block and `SUPABASE_URL`/`SUPABASE_KEY` reads from all four submit functions. Supabase ran **only after a successful Notion write** (Notion failure threw first), so it was a redundant mirror of data Notion already had — never a fallback for failed submissions. Removing it doesn't change what incoming data is captured. Netlify env-var cleanup and the historical data export are handled separately.

## Scope notes
- Brevo email calls are unchanged (still plain `fetch`).
- Map data is now up to 60s stale — fine for stoa/seeker locations that change rarely.
- A separate volunteer-form URL-field fix was explored and dropped: Notion's `url` property actually accepts arbitrary text (confirmed by live data), so it wasn't the cause of the reported failures, and normalizing would have discarded applicant free-text. Root cause to be investigated when the volunteer pages are unhidden.

## Testing
- `node -c` on all changed functions.
- No remaining `supabase` references in `netlify/functions/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)