### PR TITLE
Fix volunteer URL-field rejections and remove Supabase mirror

### DIFF
--- a/assets/js/apply-handler.js
+++ b/assets/js/apply-handler.js
@@ -1,3 +1,18 @@
+// Coerce a user-entered link into a well-formed URL, or '' if it can't be one.
+// The LinkedIn/Website inputs are free text, so people paste bare domains
+// ("linkedin.com/in/jane") or notes; Notion's URL property rejects those.
+function normalizeUrl(value) {
+  const raw = (value || '').trim()
+  if (!raw) return ''
+  const candidate = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`
+  try {
+    const url = new URL(candidate)
+    return url.hostname.includes('.') ? candidate : ''
+  } catch {
+    return ''
+  }
+}
+
 document
   .getElementById('volunteer-application')
   .addEventListener('submit', async (e) => {
@@ -21,8 +36,8 @@ document
       location: form.location.value,
       latitude: parseFloat(form.latitude.value),
       longitude: parseFloat(form.longitude.value),
-      linkedin_url: form.linkedin.value,
-      portfolio_url: form.website.value,
+      linkedin_url: normalizeUrl(form.linkedin.value),
+      portfolio_url: normalizeUrl(form.website.value),
       why_interested: form.why_interested.value,
       hopes: form.gain_from_experience.value,
       start_date: form.start_date.value,

--- a/netlify/functions/submit-contact.js
+++ b/netlify/functions/submit-contact.js
@@ -11,8 +11,6 @@ exports.handler = async function handler(event) {
 
   const ip = event.headers['x-nf-client-connection-ip'] || 'unknown'
 
-  const SUPABASE_URL = process.env.SUPABASE_URL
-  const SUPABASE_KEY = process.env.SUPABASE_KEY
   const BREVO_API_KEY = process.env.BREVO_API_KEY
   const NOTION_API_KEY = process.env.NOTION_API_KEY
   const NOTION_CONTACT_DB_ID = process.env.NOTION_CONTACT_DB_ID
@@ -42,35 +40,6 @@ exports.handler = async function handler(event) {
     })
     if (!notionRes.ok) {
       throw new Error(`Notion error: ${await notionRes.text()}`)
-    }
-
-    // Save to Supabase (non-fatal mirror)
-    if (SUPABASE_URL && SUPABASE_KEY) {
-      try {
-        const supabaseRes = await fetch(
-          `${SUPABASE_URL}/rest/v1/contact_submissions`,
-          {
-            method: 'POST',
-            headers: {
-              apikey: SUPABASE_KEY,
-              Authorization: `Bearer ${SUPABASE_KEY}`,
-              'Content-Type': 'application/json',
-              Prefer: 'return=representation',
-            },
-            body: JSON.stringify({
-              name,
-              email,
-              message,
-              ip_address: ip,
-            }),
-          }
-        )
-        if (!supabaseRes.ok) {
-          console.warn('Supabase error (non-fatal):', await supabaseRes.text())
-        }
-      } catch (supabaseErr) {
-        console.warn('Supabase error (non-fatal):', supabaseErr.message)
-      }
     }
 
     // Send Email via Brevo (non-fatal)

--- a/netlify/functions/submit-join-stoa.js
+++ b/netlify/functions/submit-join-stoa.js
@@ -20,8 +20,6 @@ exports.handler = async function handler(event) {
     consent,
   } = JSON.parse(event.body)
 
-  const SUPABASE_URL = process.env.SUPABASE_URL
-  const SUPABASE_KEY = process.env.SUPABASE_KEY
   const BREVO_API_KEY = process.env.BREVO_API_KEY
   const NOTION_API_KEY = process.env.NOTION_API_KEY
   const NOTION_JOIN_STOA_DB_ID = process.env.NOTION_JOIN_STOA_DB_ID
@@ -63,42 +61,6 @@ exports.handler = async function handler(event) {
     })
     if (!notionRes.ok) {
       throw new Error(`Notion error: ${await notionRes.text()}`)
-    }
-
-    // Save to Supabase (non-fatal mirror)
-    if (SUPABASE_URL && SUPABASE_KEY) {
-      try {
-        const supabaseRes = await fetch(
-          `${SUPABASE_URL}/rest/v1/join_stoa_submissions`,
-          {
-            method: 'POST',
-            headers: {
-              apikey: SUPABASE_KEY,
-              Authorization: `Bearer ${SUPABASE_KEY}`,
-              'Content-Type': 'application/json',
-              Prefer: 'return=representation',
-            },
-            body: JSON.stringify({
-              name,
-              email,
-              location,
-              latitude,
-              longitude,
-              preferred_language,
-              meeting_preference,
-              additional_details,
-              consent,
-              ip_address,
-              submitted_at: new Date().toISOString(),
-            }),
-          }
-        )
-        if (!supabaseRes.ok) {
-          console.warn('Supabase error (non-fatal):', await supabaseRes.text())
-        }
-      } catch (supabaseErr) {
-        console.warn('Supabase error (non-fatal):', supabaseErr.message)
-      }
     }
 
     // Send notification via Brevo (non-fatal)

--- a/netlify/functions/submit-stoa.js
+++ b/netlify/functions/submit-stoa.js
@@ -1,4 +1,5 @@
 const fetch = require('node-fetch')
+const { normalizeUrl } = require('./utils/sanitize')
 
 const txt = (val) => [{ text: { content: String(val ?? '').slice(0, 2000) } }]
 
@@ -31,8 +32,6 @@ exports.handler = async function handler(event) {
 
   const ip = event.headers['x-nf-client-connection-ip'] || 'unknown'
 
-  const SUPABASE_URL = process.env.SUPABASE_URL
-  const SUPABASE_KEY = process.env.SUPABASE_KEY
   const BREVO_API_KEY = process.env.BREVO_API_KEY
   const NOTION_API_KEY = process.env.NOTION_API_KEY
   const NOTION_STOA_DB_ID = process.env.NOTION_STOA_DB_ID
@@ -57,7 +56,7 @@ exports.handler = async function handler(event) {
           Location: { rich_text: txt(location) },
           Latitude: { number: latitude !== '' && latitude != null ? parseFloat(latitude) : null },
           Longitude: { number: longitude !== '' && longitude != null ? parseFloat(longitude) : null },
-          Website: { url: website || null },
+          Website: { url: normalizeUrl(website) },
           Language: { rich_text: txt(stoa_language) },
           Timezone: { rich_text: txt(timezone) },
           'Meeting Frequency': select(meeting_frequency),
@@ -71,45 +70,6 @@ exports.handler = async function handler(event) {
     })
     if (!notionRes.ok) {
       throw new Error(`Notion error: ${await notionRes.text()}`)
-    }
-
-    // Save to Supabase (non-fatal mirror)
-    if (SUPABASE_URL && SUPABASE_KEY) {
-      try {
-        const supabaseRes = await fetch(
-          `${SUPABASE_URL}/rest/v1/stoa_submissions`,
-          {
-            method: 'POST',
-            headers: {
-              apikey: SUPABASE_KEY,
-              Authorization: `Bearer ${SUPABASE_KEY}`,
-              'Content-Type': 'application/json',
-              Prefer: 'return=representation',
-            },
-            body: JSON.stringify({
-              stoa_name,
-              stoa_type,
-              location,
-              latitude,
-              longitude,
-              website,
-              stoa_language,
-              timezone,
-              meeting_frequency,
-              description,
-              name,
-              email,
-              submitted_at,
-              ip_address: ip,
-            }),
-          }
-        )
-        if (!supabaseRes.ok) {
-          console.warn('Supabase error (non-fatal):', await supabaseRes.text())
-        }
-      } catch (supabaseErr) {
-        console.warn('Supabase error (non-fatal):', supabaseErr.message)
-      }
     }
 
     // Send Email via Brevo (non-fatal notification)

--- a/netlify/functions/submit-volunteer.js
+++ b/netlify/functions/submit-volunteer.js
@@ -1,4 +1,5 @@
 const fetch = require('node-fetch')
+const { normalizeUrl } = require('./utils/sanitize')
 
 const txt = (val) => [{ text: { content: String(val ?? '').slice(0, 2000) } }]
 
@@ -7,8 +8,6 @@ exports.handler = async function handler(event) {
     return { statusCode: 405, body: 'Method Not Allowed' }
   }
 
-  const SUPABASE_URL = process.env.SUPABASE_URL
-  const SUPABASE_KEY = process.env.SUPABASE_KEY
   const BREVO_API_KEY = process.env.BREVO_API_KEY
   const NOTION_API_KEY = process.env.NOTION_API_KEY
   const NOTION_VOLUNTEER_DB_ID = process.env.NOTION_VOLUNTEER_DB_ID
@@ -38,8 +37,8 @@ exports.handler = async function handler(event) {
           Location: { rich_text: txt(applicantData.location) },
           Latitude: { number: applicantData.latitude ?? null },
           Longitude: { number: applicantData.longitude ?? null },
-          'LinkedIn URL': { url: applicantData.linkedin_url || null },
-          'Portfolio URL': { url: applicantData.portfolio_url || null },
+          'LinkedIn URL': { url: normalizeUrl(applicantData.linkedin_url) },
+          'Portfolio URL': { url: normalizeUrl(applicantData.portfolio_url) },
           'Why Interested': { rich_text: txt(applicantData.why_interested) },
           Hopes: { rich_text: txt(applicantData.hopes) },
           'Start Date': { date: applicantData.start_date ? { start: applicantData.start_date } : null },
@@ -54,33 +53,6 @@ exports.handler = async function handler(event) {
     })
     if (!notionRes.ok) {
       throw new Error(`Notion error: ${await notionRes.text()}`)
-    }
-
-    // Save to Supabase (non-fatal mirror)
-    if (SUPABASE_URL && SUPABASE_KEY) {
-      try {
-        const supabaseRes = await fetch(
-          `${SUPABASE_URL}/rest/v1/volunteer_applications`,
-          {
-            method: 'POST',
-            headers: {
-              apikey: SUPABASE_KEY,
-              Authorization: `Bearer ${SUPABASE_KEY}`,
-              'Content-Type': 'application/json',
-              Prefer: 'return=representation',
-            },
-            body: JSON.stringify({
-              ...applicantData,
-              user_ip: ip,
-            }),
-          }
-        )
-        if (!supabaseRes.ok) {
-          console.warn('Supabase error (non-fatal):', await supabaseRes.text())
-        }
-      } catch (supabaseErr) {
-        console.warn('Supabase error (non-fatal):', supabaseErr.message)
-      }
     }
 
     // Format HTML email content

--- a/netlify/functions/utils/sanitize.js
+++ b/netlify/functions/utils/sanitize.js
@@ -1,0 +1,20 @@
+// Coerce a user-entered value into something Notion's `url` property will
+// accept, or null. Notion rejects a `url` value that isn't a well-formed URI
+// (missing scheme, embedded spaces, or plain text) with a validation_error,
+// which fails the whole page create. Applicants routinely type bare domains
+// ("linkedin.com/in/jane") or free text, so normalize before sending.
+function normalizeUrl(value) {
+  const raw = String(value ?? '').trim()
+  if (!raw) return null
+  const candidate = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`
+  try {
+    const url = new URL(candidate)
+    // Require a dotted hostname so free text like "n/a" collapses to null
+    // rather than becoming "https://n/a".
+    return url.hostname.includes('.') ? candidate : null
+  } catch {
+    return null
+  }
+}
+
+module.exports = { normalizeUrl }


### PR DESCRIPTION
## Summary
Two related changes to the Notion-backed submit functions.

### 1. Fix volunteer submissions failing on URL fields
Volunteer applications were failing for *some* applicants but not others. Root cause: the LinkedIn and Website inputs (`apply.html`) are free text, so applicants entered bare domains (`linkedin.com/in/jane`), notes, or blanks. Those values flowed unmodified into Notion's `url`-type properties (`LinkedIn URL`, `Portfolio URL`), which reject anything that isn't a well-formed URI — throwing and failing the whole page create, so nothing was stored.

This was **value-dependent, not role-dependent**: every role links to the same `apply.html` and posts through the same `submit-volunteer` function (the role only sets a `rich_text` title and an unused slug). The failures scattered across roles because they tracked what each applicant typed.

Fix:
- New `netlify/functions/utils/sanitize.js` → `normalizeUrl()`: trims, prepends `https://` when the scheme is missing, requires a dotted hostname, else returns `null`. So bare domains become valid URLs and junk (`n/a`, free text) becomes `null` instead of a hard failure.
- Applied server-side to the volunteer LinkedIn/Portfolio URLs **and** the stoa `Website` field (`submit-stoa.js` had the identical latent bug on a live form).
- Matching client-side normalization in `apply-handler.js` so the stored value is clean regardless.

### 2. Remove the Supabase mirror
Removed the non-fatal Supabase block and `SUPABASE_URL`/`SUPABASE_KEY` reads from all four submit functions. Supabase ran **only after a successful Notion write** (Notion failure threw first), so it was a redundant mirror of data Notion already had — never a fallback for failed submissions. Removing it doesn't change what incoming data is captured.

Env-var cleanup in Netlify and the historical Supabase data export are being handled separately.

## Testing
- `node -c` on all changed functions + `apply-handler.js`.
- No remaining `supabase` references in `netlify/functions/`.
- Best tested by submitting the volunteer form in the preview deploy with a bare-domain LinkedIn value (e.g. `linkedin.com/in/test`) and confirming the row lands in Notion.

## Note on overlap with #21
This touches the same four `submit-*` functions as the still-open #21 (Notion 429 retry). Whichever merges second will need a small conflict resolution on the Notion fetch line. `utils/sanitize.js` and #21's `utils/notion-fetch.js` are separate files and don't collide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)