### PR TITLE
Exclude hidden volunteer pages from Netlify deploy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ Spanish-language versions of key pages live in `/es/`. If updating English conte
 
 ## Temporarily Hidden: Volunteer Pages
 
-The volunteer section has been hidden (not deleted) as of 2026-05-16. All code is intact and can be restored by reverting three small changes:
+The volunteer section has been hidden (not deleted) as of 2026-05-16. All code is intact and can be restored by reverting these changes:
 
 1. **`_redirects`** — remove the three redirect lines at the top of the file:
    ```
@@ -47,5 +47,7 @@ The volunteer section has been hidden (not deleted) as of 2026-05-16. All code i
 3. **`team.html`** — uncomment the "Have skills you want to contribute?" paragraph block (around line 62) and the two "Join the Team" button blocks (lines ~58 and ~74).
 
 4. **`service/index.html`** — uncomment the "Sign up to volunteer with us" section (around line 249).
+
+5. **`netlify.toml`** — remove the `command = "rm -f volunteer.html volunteer/apply.html volunteer/role.html"` line from the `[build]` section. This command strips the volunteer pages from the deploy artifact so they aren't reachable directly (the `_redirects` rules only cover the extensionless pretty paths). The files remain in git; they're only deleted from each build's output.
 
 The volunteer pages themselves (`volunteer.html`, `volunteer/apply.html`, `volunteer/role.html`) and all supporting files (`assets/js/load-volunteers.js`, `netlify/functions/submit-volunteer.js`, etc.) were not modified.

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,10 @@
 [build]
   publish = "."                    # publish from repo root
   functions = "netlify/functions"  # where your functions live
+  # Volunteer pages are temporarily hidden — strip them from the deploy so the
+  # .html files aren't reachable directly (redirects only cover the pretty
+  # paths). Files stay in git; to restore, remove this command. See CLAUDE.md.
+  command = "rm -f volunteer.html volunteer/apply.html volunteer/role.html"
 
 [functions]
   node_bundler = "esbuild"


### PR DESCRIPTION
## Summary
The volunteer section is hidden, but only via `_redirects` rules that match the extensionless pretty paths (`/volunteer`, `/volunteer/apply`, `/volunteer/role`). The actual `.html` files still shipped in the deploy and were **directly reachable** (e.g. `/volunteer/apply.html`), which is how people have been finding them via search.

This adds a Netlify build command that deletes the three volunteer HTML files from the deploy artifact, so they aren't served at all:

```toml
command = "rm -f volunteer.html volunteer/apply.html volunteer/role.html"
```

## Notes
- **Files stay in git** — they're only removed from each build's published output. Restore = delete the `command` line (documented in the CLAUDE.md "Temporarily Hidden" restore steps, now step 5).
- Only three files exist and no Spanish copy (`/es/`) — verified.
- The existing `_redirects` rules are left in place so `/volunteer` still 302s to home; the `.html` paths now fall through to the `/* /404` catch-all since the files are gone.

## Verifying after deploy
On the Deploy Preview, `…/volunteer/apply.html` should return 404 rather than the form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)