### PR TITLE
Add embeddable Stoa map for third-party iframes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,15 @@ Static HTML/CSS/JS site for The Stoic Fellowship. No build step — edit files d
 - Hosted on **Netlify**, published from repo root (see `netlify.toml`)
 - Routing is controlled by **`_redirects`** — check there first if a URL isn't resolving
 - Netlify Functions live in `netlify/functions/` and are bundled with esbuild
+- Response headers are set in **`_headers`** (currently only the framing policy for `/embed/*`)
+
+### Embeddable map
+
+`embed/map.html` is a standalone, chrome-free version of the Stoa map for `<iframe>` embedding in third-party pages (currently the Mighty Networks community at `social.stoicfellowship.com`). Because it's served from our own origin, `assets/js/map.js` keeps calling `/.netlify/functions/*` same-origin — no CORS config and no credentials leave the site.
+
+- It reuses `assets/js/map.js` unchanged; the Mapbox popup/marker CSS is duplicated inline so the embed doesn't pull in all of `main.css`. **If you change the "Mapbox Styling" section of `assets/css/main.css`, mirror it there.**
+- Framing is restricted by `frame-ancestors` in `_headers`. To allow a new host, add its origin there. Don't add `X-Frame-Options` — its `ALLOW-FROM` directive is dead and some browsers treat it as `DENY`.
+- Height is controlled by the embedding page's `<iframe>`, not by us — the page fills 100% of whatever frame it's given.
 
 ## Forms & Backend
 

--- a/_headers
+++ b/_headers
@@ -1,0 +1,8 @@
+# Allow the embeddable map to be framed only by our own site and our
+# Mighty Networks community. Everything outside /embed/ is untouched.
+#
+# Note: deliberately no X-Frame-Options here. Its ALLOW-FROM directive is
+# dead in every modern browser and some treat it as DENY, which would break
+# the embed. frame-ancestors covers this and takes precedence.
+/embed/*
+  Content-Security-Policy: frame-ancestors 'self' https://social.stoicfellowship.com https://*.mightynetworks.com

--- a/embed/map.html
+++ b/embed/map.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Stoa Map — The Stoic Fellowship</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex" />
+  <link href="https://fonts.googleapis.com/css2?family=Dosis:wght@200;400;700&display=swap" rel="stylesheet" />
+  <link href="https://api.mapbox.com/mapbox-gl-js/v2.14.1/mapbox-gl.css" rel="stylesheet" />
+  <link href="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.css" rel="stylesheet" />
+
+  <!--
+    Standalone map for embedding in third-party pages via <iframe>.
+    Served from our own origin, so assets/js/map.js can keep calling
+    /.netlify/functions/* same-origin — no CORS, no exposed Notion keys.
+    Deliberately omits headerFooter.js, main.js/jQuery and analytics.
+    Framing is restricted in _headers. See CLAUDE.md.
+  -->
+
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      height: 100%;
+      background: #fff;
+    }
+
+    #map {
+      width: 100%;
+      height: 100%;
+    }
+
+    /* Map styling mirrored from assets/css/main.css ("Mapbox Styling" section).
+       Kept inline so the embed doesn't pull in the whole site stylesheet. */
+
+    .mapboxgl-marker.seeker-marker {
+      z-index: 1 !important;
+    }
+
+    .mapboxgl-marker.stoa-marker {
+      z-index: 2 !important;
+    }
+
+    .mapboxgl-popup {
+      width: 250px;
+      max-width: 250px !important;
+      font-family: Dosis, sans-serif;
+      font-size: 14px;
+      z-index: 10;
+      animation: popupFadeIn 0.22s ease-out;
+    }
+
+    @keyframes popupFadeIn {
+      from { opacity: 0; }
+      to { opacity: 1; }
+    }
+
+    .mapboxgl-popup .mapboxgl-popup-content {
+      width: 250px;
+      box-sizing: border-box;
+      padding: 0 !important;
+      background-color: #fff !important;
+      border-radius: 18px !important;
+      border: none !important;
+      overflow: hidden !important;
+      box-shadow: 0 22px 50px rgba(0, 0, 0, 0.28), 0 8px 18px rgba(0, 0, 0, 0.14) !important;
+    }
+
+    .popup-member { --popup-accent: #880E4F; }
+    .popup-active { --popup-accent: #E65100; }
+    .popup-seeker { --popup-accent: #008080; }
+
+    .popup-body {
+      padding: 16px 20px 18px;
+    }
+
+    .popup-type {
+      display: block;
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--popup-accent);
+      margin-bottom: 4px;
+    }
+
+    .popup-name {
+      font-size: 20px;
+      font-weight: 700;
+      margin: 0 0 6px;
+      color: #222;
+      line-height: 1.2;
+    }
+
+    .popup-location {
+      font-size: 14px;
+      color: #666;
+      margin: 0;
+    }
+
+    .popup-tag {
+      display: inline-block;
+      font-size: 12px;
+      background: #f1f1f1;
+      color: #555;
+      padding: 2px 10px;
+      border-radius: 999px;
+      margin-top: 10px;
+    }
+
+    .popup-cta {
+      display: block;
+      width: 100%;
+      box-sizing: border-box;
+      margin-top: 18px;
+      padding: 9px 14px;
+      border-radius: 8px;
+      background: color-mix(in srgb, var(--popup-accent) 10%, #fff);
+      color: var(--popup-accent) !important;
+      font-weight: 600;
+      font-size: 13px;
+      text-align: center;
+      text-decoration: none !important;
+      border: none;
+      outline: none;
+      -webkit-tap-highlight-color: transparent;
+      transition: background-color 0.15s ease;
+    }
+
+    .popup-cta:focus,
+    .popup-cta:focus-visible {
+      outline: none;
+    }
+
+    .popup-cta:hover {
+      background: color-mix(in srgb, var(--popup-accent) 18%, #fff);
+    }
+
+    .mapboxgl-ctrl-geocoder {
+      float: none !important;
+      margin: 10px 0 0 10px;
+      border-radius: 8px !important;
+    }
+
+    .mapboxgl-ctrl-geocoder input {
+      padding-left: 35px !important;
+      border-radius: 8px !important;
+      height: 60px !important;
+      font-family: Dosis, sans-serif;
+    }
+
+    .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--icon {
+      top: 50% !important;
+      transform: translateY(-50%) !important;
+      left: 10px !important;
+      color: rgba(124, 128, 129, 0.5) !important;
+    }
+
+    /* The frame is short on phones — reclaim vertical space from the search box
+       and keep popups inside the viewport. */
+    @media screen and (max-width: 736px) {
+      .mapboxgl-ctrl-geocoder {
+        min-width: 0 !important;
+        width: calc(100% - 60px) !important;
+        margin: 8px 0 0 8px;
+      }
+
+      .mapboxgl-ctrl-geocoder input {
+        height: 42px !important;
+        font-size: 16px !important; /* anything smaller makes iOS Safari zoom on focus */
+      }
+
+      .mapboxgl-popup,
+      .mapboxgl-popup .mapboxgl-popup-content {
+        width: 210px;
+        max-width: 210px !important;
+      }
+    }
+  </style>
+</head>
+
+<body>
+  <div id="map"></div>
+
+  <script src="https://api.mapbox.com/mapbox-gl-js/v2.14.1/mapbox-gl.js"></script>
+  <script src="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.min.js"></script>
+  <script src="/assets/js/map.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## What

Adds `embed/map.html` — a standalone, chrome-free version of the Stoa map built for `<iframe>` embedding in third-party pages, specifically the Mighty Networks community at `social.stoicfellowship.com`.

## Why this approach

Serving the embed from our own origin means `assets/js/map.js` keeps calling `/.netlify/functions/*` same-origin. No CORS headers to add, no Notion or Mapbox credentials leaving the site, and existing Mapbox URL restrictions keep working (the iframe document's origin is still ours — the parent page's domain is irrelevant to Mapbox).

The alternative, a `<script>`-tag embed, would have required opening up CORS on both functions and re-tightening the Mapbox token. Worth revisiting only if Mighty Networks turns out to strip iframes.

## Changes

- **`embed/map.html`** — reuses `assets/js/map.js` unchanged. Drops `headerFooter.js`, jQuery, `main.js` and Matomo; marked `noindex`. Mapbox popup/marker CSS is inlined rather than pulling in all of `main.css`.
- **`_headers`** (new file) — `frame-ancestors 'self' https://social.stoicfellowship.com https://*.mightynetworks.com`, scoped to `/embed/*` so nothing else on the site is affected. No `X-Frame-Options`: its `ALLOW-FROM` directive is dead in modern browsers and some treat the unrecognized value as `DENY`, which would break the embed.
- **`CLAUDE.md`** — documents the page, the framing policy, and the "mirror Mapbox CSS changes" gotcha.

## Mobile

Height is set by the embedding page, not us — the map fills 100% of whatever frame it gets. The embed snippet uses `height: min(700px, 80vh)`, which is pure CSS so it survives Mighty's HTML sanitizer and doesn't render a 700px box on a phone. A `max-width: 736px` block shrinks the geocoder input (60px → 42px, which was eating a quarter of a phone screen) and narrows popups to 210px. The input is 16px so iOS Safari doesn't zoom the frame on focus. Scroll-zoom is already disabled in `map.js:36`, so the map won't hijack page scrolling.

## Embed code

```html
<iframe src="https://www.stoicfellowship.com/embed/map"
        style="width:100%; height:min(700px, 80vh); border:0; display:block;"
        loading="lazy" title="Map of Stoic communities"></iframe>
```

## Testing

Verified the page and its asset paths serve correctly (static server, both 200).

**Not verified:** there's no local `.env` and no dev script in `package.json`, so `get-mapbox-token` and `get-map-data` could not be exercised — the map actually rendering with live Notion pins is unconfirmed until this hits a deploy preview. **Please load the preview URL directly before embedding it.**

Also worth a look: `*.mightynetworks.com` is in `frame-ancestors` because Mighty sometimes serves editor previews from their own hostname. Drop it if you'd rather lock to our domain only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)