### PR TITLE
Make embed map framing configurable and zoom it out

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,13 @@ Static HTML/CSS/JS site for The Stoic Fellowship. No build step — edit files d
 
 - It reuses `assets/js/map.js` unchanged; the Mapbox popup/marker CSS is duplicated inline so the embed doesn't pull in all of `main.css`. **If you change the "Mapbox Styling" section of `assets/css/main.css`, mirror it there.**
 - Framing is restricted by `frame-ancestors` in `_headers`. To allow a new host, add its origin there. Don't add `X-Frame-Options` — its `ALLOW-FROM` directive is dead and some browsers treat it as `DENY`.
-- Height is controlled by the embedding page's `<iframe>`, not by us — the page fills 100% of whatever frame it's given.
+- Height is controlled by the embedding page's `<iframe>`, not by us — the page fills 100% of whatever frame it's given. **Mighty Networks strips the `style` height**, so the working snippet uses the `height` attribute:
+  ```html
+  <iframe src="https://www.stoicfellowship.com/embed/map"
+          width="100%" height="420" style="border:0; display:block;"
+          loading="lazy" title="Map of Stoic communities"></iframe>
+  ```
+- Initial framing comes from `DEFAULT_VIEW` in `assets/js/map.js`, overridable by `window.TSF_MAP_VIEW` (the embed sets a wider view for its short frame) and then by `?zoom=` / `?center=lng,lat` on the URL. The query params let the embed be re-framed from the iframe `src` without a deploy.
 
 ## Forms & Backend
 

--- a/assets/js/map.js
+++ b/assets/js/map.js
@@ -13,15 +13,36 @@ function escape(str) {
     .replace(/"/g, '&quot;')
 }
 
+const DEFAULT_VIEW = { center: [-25, 20], zoom: 1.6 }
+
+// Framing is overridable so the embed (embed/map.html) can zoom out to suit a
+// short iframe without changing how the map looks on the site itself. A page
+// can set window.TSF_MAP_VIEW, and the URL wins over that so the framing can be
+// tuned straight from the embed's src without a deploy. See CLAUDE.md.
+function resolveView() {
+  const view = { ...DEFAULT_VIEW, ...(window.TSF_MAP_VIEW || {}) }
+  const params = new URLSearchParams(window.location.search)
+
+  const zoom = Number(params.get('zoom'))
+  if (params.get('zoom') && Number.isFinite(zoom)) view.zoom = zoom
+
+  const center = (params.get('center') || '').split(',').map(Number)
+  if (center.length === 2 && center.every(Number.isFinite)) view.center = center
+
+  return view
+}
+
 ;(async function initializeMap() {
   try {
     mapboxgl.accessToken = await fetchMapboxToken()
 
+    const { center, zoom } = resolveView()
+
     const map = new mapboxgl.Map({
       container: 'map',
       style: 'mapbox://styles/mapbox/light-v10',
-      center: [-25, 20],
-      zoom: 1.6,
+      center,
+      zoom,
       attributionControl: false,
     })
 

--- a/embed/map.html
+++ b/embed/map.html
@@ -182,6 +182,12 @@
 <body>
   <div id="map"></div>
 
+  <script>
+    // The embed sits in a short, wide iframe, so it needs to be zoomed out
+    // further than the full-page map. Override per-embed with ?zoom= / ?center=
+    // on the iframe src.
+    window.TSF_MAP_VIEW = { center: [-25, 25], zoom: 0.9 }
+  </script>
   <script src="https://api.mapbox.com/mapbox-gl-js/v2.14.1/mapbox-gl.js"></script>
   <script src="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.min.js"></script>
   <script src="/assets/js/map.js"></script>


### PR DESCRIPTION
## What

The embedded map sits in a short, wide iframe (`height="420"`), where the full-page map's zoom of `1.6` is too tight.

`assets/js/map.js` is shared with `stoic-groups.html` and the other site pages, so this doesn't just change the number. Framing is now a `DEFAULT_VIEW` that a page can override with `window.TSF_MAP_VIEW`, which the URL can in turn override with `?zoom=` / `?center=lng,lat`.

- **Site pages are unaffected** — with no override present they still get `center [-25, 20]` at `zoom 1.6`.
- **The embed** sets `center [-25, 25]` at `zoom 0.9`.
- **The query params matter for iteration**: the embed's framing can now be retuned straight from the iframe `src` in Mighty Networks, with no deploy and no round-trip through me.

## Also

Records the working Mighty Networks snippet in `CLAUDE.md`. Mighty strips the `style` height, so the embed needs the presentational `height` attribute — worth writing down, since it cost a couple of attempts to find.

## Testing

Verified `resolveView()` against the real inputs:

| page | query | result |
|---|---|---|
| site (no override) | — | `center [-25,20]`, `zoom 1.6` |
| embed | — | `center [-25,25]`, `zoom 0.9` |
| embed | `?zoom=1.2&center=10,10` | `center [10,10]`, `zoom 1.2` |
| embed | `?zoom=` / `?zoom=abc` | falls back to `0.9` |
| embed | `?center=abc,def` | falls back to `[-25,25]` |

Empty and malformed params fall back rather than coercing — `?zoom=` would otherwise have become `0` and zoomed all the way out.

As with #24, the functions can't run locally (no `.env`, no dev script), so confirm on the deploy preview.

## Tuning

If `0.9` still isn't right, no code change needed — try `?zoom=0.7` on the iframe `src` and tell me the value that looks good, and I'll fold it into the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)