### PR TITLE
Cache-bust map.js from the embed page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ Static HTML/CSS/JS site for The Stoic Fellowship. No build step — edit files d
           loading="lazy" title="Map of Stoic communities"></iframe>
   ```
 - Initial framing comes from `DEFAULT_VIEW` in `assets/js/map.js`, overridable by `window.TSF_MAP_VIEW` (the embed sets a wider view for its short frame) and then by `?zoom=` / `?center=lng,lat` on the URL. The query params let the embed be re-framed from the iframe `src` without a deploy.
+- **Bump the `?v=` on the `map.js` script tag in `embed/map.html` whenever you change `map.js`.** HTML is served `max-age=0` but JS is served `max-age=14400` (4h), so otherwise the fresh page runs a stale script — which looks exactly like "the deploy didn't work."
 
 ## Forms & Backend
 

--- a/embed/map.html
+++ b/embed/map.html
@@ -190,6 +190,9 @@
   </script>
   <script src="https://api.mapbox.com/mapbox-gl-js/v2.14.1/mapbox-gl.js"></script>
   <script src="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.min.js"></script>
-  <script src="/assets/js/map.js"></script>
+  <!-- Versioned: this page is served no-cache but map.js is cached for 4h, so
+       without a version bump the fresh HTML runs a stale script. Bump ?v= on
+       any change to map.js that the embed depends on. See CLAUDE.md. -->
+  <script src="/assets/js/map.js?v=20260726"></script>
 </body>
 </html>


### PR DESCRIPTION
## The symptom

After #25 merged and deployed, the embed still rendered at the **old** zoom of 1.6. Measuring the visible span in a screenshot of the live community page (~-112° to +58° across ~705 CSS px) confirms zoom ≈1.55 — the pre-#25 default.

## The cause

Not a deploy failure. The live page really does serve the new setting:

```
$ curl -s https://www.stoicfellowship.com/embed/map | grep TSF_MAP_VIEW
    window.TSF_MAP_VIEW = { center: [-25, 25], zoom: 0.9 }
```

The two halves of the fix ship together but don't *arrive* together, because their cache headers differ:

| asset | `cache-control` |
|---|---|
| `embed/map.html` | `public, max-age=0, must-revalidate` |
| `assets/js/map.js` | `public, max-age=14400, must-revalidate` |

So a browser fetches the fresh HTML with its new `window.TSF_MAP_VIEW`, then runs a **4-hour-stale `map.js`** that has never heard of that variable and hardcodes zoom 1.6. It looks exactly like a failed deploy.

## The fix

Pins the script to `?v=20260726` so the new framing takes effect immediately, rather than whenever each visitor's cache happens to expire. `CLAUDE.md` now says to bump it alongside any `map.js` change the embed depends on.

Left the site's own pages alone — they load `map.js` too, but #25 kept their defaults identical, so a stale copy there renders the same either way.

## Note on the versioning

`?v=` is a manual bump, which is a real tradeoff: forget it and this recurs. It fits a repo with no build step, but the sturdier alternative is a `_headers` rule dropping `max-age` on `/assets/js/*`, at the cost of revalidation on every page load site-wide. Happy to switch if you'd rather not rely on remembering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)